### PR TITLE
Fix dark mode toggle

### DIFF
--- a/assets/js/mondo.js
+++ b/assets/js/mondo.js
@@ -29,7 +29,7 @@ const disableDarkMode = () => {
     changeCSS('assets/css/bootstrap.min.css', 'assets/css/bootstrap-dark.min.css'); 
     changeCSS('assets/css/app.min.css', 'assets/css/app-dark.min.css'); 
     // 2. update darkMode in localStorage
-        localStorage.setItem('darkMode', null);
+    localStorage.removeItem('darkMode');
 }
 
 if(darkMode === 'enabled'){


### PR DESCRIPTION
## Summary
- clear `darkMode` from local storage instead of setting `null`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685fab9ba6c0832db2654395fa71b6e6